### PR TITLE
Bump build number and build with Rust 1.82

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e4fb026cc367e0dff7d0b8a2fce510e66d5bf7ef4728af76bfe63132b22753cd
 
 build:
-  number: 0
+  number: 1
   # 2023/5/29: On win64 `rust_compiler_rust-gnu` tries to create two artifacts with different hashes in the artifact's filename,
   # and testing one of them fails but another succeeded.
   skip: True  # [win64 and (rust_compiler == 'rust-gnu')]


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6215](https://anaconda.atlassian.net/browse/PKG-6215)
 
### Explanation of changes:
  - Bump build number and build with rust 1.82

Rust < 1.81 was affected by CVE-2024-43402.

[PKG-6215]: https://anaconda.atlassian.net/browse/PKG-6215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ