### PR TITLE
Update recipe for py313_codesign

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sudachipy" %}
-{% set version = "0.6.7" %}
+{% set version = "0.6.10" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/SudachiPy-{{ version }}.tar.gz
-  sha256: e4fb026cc367e0dff7d0b8a2fce510e66d5bf7ef4728af76bfe63132b22753cd
+  sha256: b8910a4610de98b2c3cb6dc3362fea93e3ba5059f1eb445a68baa9585278f31b
 
 build:
-  number: 2
+  number: 0
   # 2023/5/29: On win64 `rust_compiler_rust-gnu` tries to create two artifacts with different hashes in the artifact's filename,
   # and testing one of them fails but another succeeded.
   skip: True  # [win64 and (rust_compiler == 'rust-gnu')]
@@ -27,8 +27,8 @@ requirements:
     - pip
     - python
     - setuptools
-    - setuptools-rust
     - wheel
+    - setuptools-rust
   run:
     - python
     - {{ pin_compatible("libgcc-ng", max_pin=None) }} # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,15 +6,15 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/SudachiPy-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/sudachipy-{{ version }}.tar.gz
   sha256: b8910a4610de98b2c3cb6dc3362fea93e3ba5059f1eb445a68baa9585278f31b
 
 build:
   number: 0
-  # 2023/5/29: On win64 `rust_compiler_rust-gnu` tries to create two artifacts with different hashes in the artifact's filename,
-  # and testing one of them fails but another succeeded.
-  skip: True  # [win64 and (rust_compiler == 'rust-gnu')]
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: 
+    - curl -O https://github.com/WorksApplications/sudachi.rs/blob/v{{ version }}/LICENSE
+    - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - sudachipy=sudachipy.command_line:main
   missing_dso_whitelist:  # [s390x]
@@ -22,7 +22,10 @@ build:
 
 requirements:
   build:
+    - {{ compiler("c") }}
     - {{ compiler('rust') }}
+    - cargo-bundle-licenses
+    - curl
   host:
     - pip
     - python
@@ -31,7 +34,6 @@ requirements:
     - setuptools-rust
   run:
     - python
-    - {{ pin_compatible("libgcc-ng", max_pin=None) }} # [linux]
 
 test:
   imports:
@@ -48,9 +50,10 @@ about:
   doc_url: https://github.com/WorksApplications/sudachi.rs/tree/develop/python
   summary: Python version of Sudachi, the Japanese Morphological Analyzer
   description: Python version of Sudachi, the Japanese Morphological Analyzer
-  license: Apache-2.0
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
   license_family: Apache
-  license_url: https://github.com/WorksApplications/sudachi.rs/blob/develop/LICENSE
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,7 @@ about:
   doc_url: https://github.com/WorksApplications/sudachi.rs/tree/develop/python
   summary: Python version of Sudachi, the Japanese Morphological Analyzer
   description: Python version of Sudachi, the Japanese Morphological Analyzer
+  license: Apache-2.0
   license_file:
     - LICENSE
     - THIRDPARTY.yml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e4fb026cc367e0dff7d0b8a2fce510e66d5bf7ef4728af76bfe63132b22753cd
 
 build:
-  number: 1
+  number: 2
   # 2023/5/29: On win64 `rust_compiler_rust-gnu` tries to create two artifacts with different hashes in the artifact's filename,
   # and testing one of them fails but another succeeded.
   skip: True  # [win64 and (rust_compiler == 'rust-gnu')]


### PR DESCRIPTION
Rebuild for codesigned win-64 py313 artifacts.

update to 0.6.10
https://github.com/WorksApplications/sudachi.rs/blob/v0.6.10/python/CHANGELOG.md